### PR TITLE
feature/add tests

### DIFF
--- a/src/__tests__/app/auth/context/auth-store.test.tsx
+++ b/src/__tests__/app/auth/context/auth-store.test.tsx
@@ -472,4 +472,23 @@ describe('AuthStore', () => {
       )
     })
   })
+
+  describe('reauthenticateWithEmailAndPassword', () => {
+    it('should return error to reauthenticate user', async () => {
+      const emailMock = faker.internet.email()
+      const passwordMock = faker.internet.password({length: 8})
+
+      authStore.setFirebaseUser(undefined)
+
+      // SUT
+      const sut = authStore.reauthenticateWithEmailAndPassword(
+        emailMock,
+        passwordMock,
+      )
+
+      expect(sut).rejects.toBe(ERROR_MESSAGES['user-not-found'])
+    })
+
+    it.todo('should reauthenticate user')
+  })
 })

--- a/src/__tests__/app/auth/context/auth-store.test.tsx
+++ b/src/__tests__/app/auth/context/auth-store.test.tsx
@@ -474,7 +474,7 @@ describe('AuthStore', () => {
   })
 
   describe('reauthenticateWithEmailAndPassword', () => {
-    it('should return error to reauthenticate user', async () => {
+    it('should return error if firebaseUser does not exists', async () => {
       const emailMock = faker.internet.email()
       const passwordMock = faker.internet.password({length: 8})
 
@@ -489,6 +489,58 @@ describe('AuthStore', () => {
       expect(sut).rejects.toBe(ERROR_MESSAGES['user-not-found'])
     })
 
-    it.todo('should reauthenticate user')
+    it('should reauthenticate user', async () => {
+      const emailMock = faker.internet.email()
+      const passwordMock = faker.internet.password({length: 8})
+      const authResponseDummy = {
+        user: makeFbUser(),
+        operationType: 'signIn',
+        providerId: 'some-id',
+      } as firebaseAuth.UserCredential
+
+      authStore.setFirebaseUser(makeFbUser())
+
+      jest
+        .spyOn(firebaseAuth.EmailAuthProvider, 'credential')
+        .mockImplementation()
+      jest
+        .spyOn(firebaseAuth, 'reauthenticateWithCredential')
+        .mockResolvedValue(authResponseDummy)
+
+      // SUT
+      const sut = authStore.reauthenticateWithEmailAndPassword(
+        emailMock,
+        passwordMock,
+      )
+
+      expect(sut).resolves.toBe(undefined)
+    })
+
+    it('should return an error to reauthenticate user', async () => {
+      const emailMock = faker.internet.email()
+      const passwordMock = faker.internet.password({length: 8})
+      const authResponseDummy = {
+        user: makeFbUser(),
+        operationType: 'signIn',
+        providerId: 'some-id',
+      } as firebaseAuth.UserCredential
+
+      authStore.setFirebaseUser(makeFbUser())
+
+      jest
+        .spyOn(firebaseAuth.EmailAuthProvider, 'credential')
+        .mockImplementation()
+      jest
+        .spyOn(firebaseAuth, 'reauthenticateWithCredential')
+        .mockResolvedValue(authResponseDummy)
+
+      // SUT
+      const sut = authStore.reauthenticateWithEmailAndPassword(
+        emailMock,
+        passwordMock,
+      )
+
+      expect(sut).resolves.toBe(undefined)
+    })
   })
 })

--- a/src/__tests__/app/auth/context/auth-store.test.tsx
+++ b/src/__tests__/app/auth/context/auth-store.test.tsx
@@ -519,11 +519,6 @@ describe('AuthStore', () => {
     it('should return an error to reauthenticate user', async () => {
       const emailMock = faker.internet.email()
       const passwordMock = faker.internet.password({length: 8})
-      const authResponseDummy = {
-        user: makeFbUser(),
-        operationType: 'signIn',
-        providerId: 'some-id',
-      } as firebaseAuth.UserCredential
 
       authStore.setFirebaseUser(makeFbUser())
 
@@ -532,7 +527,7 @@ describe('AuthStore', () => {
         .mockImplementation()
       jest
         .spyOn(firebaseAuth, 'reauthenticateWithCredential')
-        .mockResolvedValue(authResponseDummy)
+        .mockRejectedValue('')
 
       // SUT
       const sut = authStore.reauthenticateWithEmailAndPassword(
@@ -540,7 +535,29 @@ describe('AuthStore', () => {
         passwordMock,
       )
 
-      expect(sut).resolves.toBe(undefined)
+      expect(sut).rejects.toBe(ERROR_MESSAGES['error-to-authenticate-user'])
+    })
+
+    it('should return a custom error to reauthenticate user', async () => {
+      const emailMock = faker.internet.email()
+      const passwordMock = faker.internet.password({length: 8})
+
+      authStore.setFirebaseUser(makeFbUser())
+
+      jest
+        .spyOn(firebaseAuth.EmailAuthProvider, 'credential')
+        .mockImplementation()
+      jest
+        .spyOn(firebaseAuth, 'reauthenticateWithCredential')
+        .mockRejectedValue({code: 'auth/invalid-login-credentials'})
+
+      // SUT
+      const sut = authStore.reauthenticateWithEmailAndPassword(
+        emailMock,
+        passwordMock,
+      )
+
+      expect(sut).rejects.toBe(ERROR_MESSAGES['auth/invalid-login-credentials'])
     })
   })
 })

--- a/src/__tests__/app/auth/context/auth-store.test.tsx
+++ b/src/__tests__/app/auth/context/auth-store.test.tsx
@@ -454,4 +454,22 @@ describe('AuthStore', () => {
       expect(authStore.user).toBe(undefined)
     })
   })
+
+  describe('resetPassword', () => {
+    it('should send password reset email', async () => {
+      const emailMock = faker.internet.email()
+      const continueUrl = `${APP_URL}/auth`
+
+      jest.spyOn(firebaseAuth, 'sendPasswordResetEmail').mockResolvedValue()
+
+      // SUT
+      await authStore.resetPassword(emailMock)
+
+      expect(firebaseAuth.sendPasswordResetEmail).toHaveBeenCalledWith(
+        auth,
+        emailMock,
+        {url: continueUrl},
+      )
+    })
+  })
 })

--- a/src/__tests__/app/auth/context/auth-store.test.tsx
+++ b/src/__tests__/app/auth/context/auth-store.test.tsx
@@ -54,13 +54,34 @@ describe('AuthStore', () => {
 
       jest.spyOn(authStore, 'authUser').mockResolvedValue()
 
-      await expect(authStore.signInWithGoogle()).resolves.toBeFalsy()
+      await expect(authStore.signInWithGoogle()).resolves.toBeUndefined()
     })
 
     it('should call google signin and throw an error', async () => {
       jest.spyOn(firebaseAuth, 'signInWithPopup').mockRejectedValue({code: ''})
 
       await expect(authStore.signInWithGoogle()).rejects.toBe(
+        ERROR_MESSAGES['error-to-authenticate-user'],
+      )
+    })
+  })
+
+  describe('signInWithGithub', () => {
+    it('should call github, signin and update user data', async () => {
+      const firebaseUserMock = makeFbUser()
+
+      jest
+        .spyOn(firebaseAuth, 'signInWithPopup')
+        .mockResolvedValue({user: firebaseUserMock} as any)
+
+      jest.spyOn(authStore, 'authUser').mockResolvedValue()
+
+      await expect(authStore.signInWithGithub()).resolves.toBeUndefined()
+    })
+    it('should call github, signin and throw an error', async () => {
+      jest.spyOn(firebaseAuth, 'signInWithPopup').mockRejectedValue({code: ''})
+
+      await expect(authStore.signInWithGithub()).rejects.toBe(
         ERROR_MESSAGES['error-to-authenticate-user'],
       )
     })

--- a/src/__tests__/app/auth/context/auth-store.test.tsx
+++ b/src/__tests__/app/auth/context/auth-store.test.tsx
@@ -179,7 +179,45 @@ describe('AuthStore', () => {
       expect(authStore.logout).toHaveBeenCalled()
     })
 
-    it.todo('should create an account using email and password')
+    it('should return an error to create an account', async () => {
+      const firebaseUserMock = makeFbUser()
+      const userMock = parseToUser(firebaseUserMock)
+      const passwordMock = faker.internet.password({length: 8})
+      const displayNameMock = faker.internet.userName()
+
+      jest
+        .spyOn(firebaseAuth, 'createUserWithEmailAndPassword')
+        .mockRejectedValue('error')
+
+      // SUT
+      const sut = authStore.createWithEmailAndPassword({
+        email: userMock.email,
+        password: passwordMock,
+        displayName: displayNameMock,
+      })
+
+      expect(sut).rejects.toBe(ERROR_MESSAGES['error-to-create-account'])
+    })
+
+    it('should return a custom error to create an account', async () => {
+      const firebaseUserMock = makeFbUser()
+      const userMock = parseToUser(firebaseUserMock)
+      const passwordMock = faker.internet.password({length: 8})
+      const displayNameMock = faker.internet.userName()
+
+      jest
+        .spyOn(firebaseAuth, 'createUserWithEmailAndPassword')
+        .mockRejectedValue({code: 'auth/email-already-in-use'})
+
+      // SUT
+      const sut = authStore.createWithEmailAndPassword({
+        email: userMock.email,
+        password: passwordMock,
+        displayName: displayNameMock,
+      })
+
+      expect(sut).rejects.toBe(ERROR_MESSAGES['auth/email-already-in-use'])
+    })
   })
 
   describe('signInWithGithub', () => {

--- a/src/__tests__/app/auth/context/auth-store.test.tsx
+++ b/src/__tests__/app/auth/context/auth-store.test.tsx
@@ -57,11 +57,21 @@ describe('AuthStore', () => {
       await expect(authStore.signInWithGoogle()).resolves.toBeUndefined()
     })
 
-    it('should call google signin and throw an error', async () => {
+    it('should call google, signin and throw an error', async () => {
       jest.spyOn(firebaseAuth, 'signInWithPopup').mockRejectedValue({code: ''})
 
       await expect(authStore.signInWithGoogle()).rejects.toBe(
         ERROR_MESSAGES['error-to-authenticate-user'],
+      )
+    })
+
+    it('should call google, signin and throw an custom error', async () => {
+      jest
+        .spyOn(firebaseAuth, 'signInWithPopup')
+        .mockRejectedValue({code: 'auth/email-already-in-use'})
+
+      await expect(authStore.signInWithGoogle()).rejects.toBe(
+        ERROR_MESSAGES['auth/email-already-in-use'],
       )
     })
   })
@@ -83,6 +93,16 @@ describe('AuthStore', () => {
 
       await expect(authStore.signInWithGithub()).rejects.toBe(
         ERROR_MESSAGES['error-to-authenticate-user'],
+      )
+    })
+
+    it('should call github, signin and throw an custom error', async () => {
+      jest
+        .spyOn(firebaseAuth, 'signInWithPopup')
+        .mockRejectedValue({code: 'auth/email-already-in-use'})
+
+      await expect(authStore.signInWithGithub()).rejects.toBe(
+        ERROR_MESSAGES['auth/email-already-in-use'],
       )
     })
   })

--- a/src/app/auth/context/auth-store.ts
+++ b/src/app/auth/context/auth-store.ts
@@ -94,14 +94,15 @@ class AuthStore {
     displayName,
   }: SignUpWithEmailAndPassword): Promise<void> {
     try {
+      const continueUrl = `${APP_URL}/auth`
       const {user} = await createUserWithEmailAndPassword(auth, email, password)
       await updateProfile(user, {displayName})
-      await sendEmailVerification(user)
-      this.logout()
+      await sendEmailVerification(user, {url: continueUrl})
+      await this.logout()
     } catch (error: any) {
       const code = error?.code as ErrorMessagesKeys
 
-      if (Object.hasOwn(ERROR_MESSAGES, code)) throw ERROR_MESSAGES[code]
+      if (ERROR_MESSAGES[code]) throw ERROR_MESSAGES[code]
       throw ERROR_MESSAGES['error-to-create-account']
     }
   }

--- a/src/app/auth/context/auth-store.ts
+++ b/src/app/auth/context/auth-store.ts
@@ -225,11 +225,11 @@ class AuthStore {
     email: string,
     password: string,
   ) {
-    if (!auth.currentUser) throw ERROR_MESSAGES['user-not-found']
+    if (!this.firebaseUser) throw ERROR_MESSAGES['user-not-found']
 
     try {
       const credential = EmailAuthProvider.credential(email, password)
-      await reauthenticateWithCredential(auth.currentUser, credential)
+      await reauthenticateWithCredential(this.firebaseUser, credential)
     } catch (error: any) {
       const code = error?.code as ErrorMessagesKeys
 


### PR DESCRIPTION
- feat: ensure to sign in with github
- test: ensure to throw a custom error msg
- test: ensure to sign in with email and password
- test: ensure to create account using email and password
- test: ensure to throw correct error when account creation fails
- test: ensure to send password reset email
- test: ensure to return an error if firebaseUser doesn't exists
- test: ensure to reauthenticate user
- test: ensure to return an error to reauthenticate user
